### PR TITLE
Add CSV and image support

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ A web application for semantic file search built with Next.js, FastAPI, and Chro
    npm run dev
    ```
    The frontend will be available at http://localhost:3000
+   Set `NEXT_PUBLIC_BACKEND_URL` in `.env.local` if your backend runs elsewhere
 
 ## Features
 
@@ -64,6 +65,8 @@ A web application for semantic file search built with Next.js, FastAPI, and Chro
 - **Mac Notes-style UI**: Clean and intuitive interface inspired by the macOS Notes app
 - **Automatic File Indexing**: System automatically indexes files from your Downloads folder (configurable in main.py)
 - **Chroma DB Integration**: Utilizes Chroma DB for vector storage and semantic search capabilities
+- **CSV and Image Support**: Indexes CSV files and images (PNG, JPG, JPEG) in addition to PDF, DOCX, and TXT formats
+- **Batch Embedding Optimization**: Adds document chunks in batches for faster indexing
 
 ## API Endpoints
 
@@ -76,3 +79,11 @@ A web application for semantic file search built with Next.js, FastAPI, and Chro
 3. Enter your search query in the search bar at the bottom of the page
 4. View search results in the left panel
 5. Click on a result to view its full content in the right panel
+
+## Deployment on Vercel
+
+1. Install the [Vercel CLI](https://vercel.com/docs/cli) and log in
+2. From the project root, run `vercel` and follow the prompts
+3. Set the `NEXT_PUBLIC_BACKEND_URL` environment variable to your deployed FastAPI endpoint
+4. Vercel will build the Next.js frontend and the `api/index.py` serverless function
+5. After deployment, open the generated Vercel URL in your browser

--- a/api/index.py
+++ b/api/index.py
@@ -1,0 +1,1 @@
+from backend.api import app

--- a/backend/api.py
+++ b/backend/api.py
@@ -119,8 +119,29 @@ def extract_text_from_txt(file_path: Path) -> str:
     except Exception as e:
         print(f"Error extracting text from TXT {file_path}: {e}")
         return ""
-    
-# have to do csv , excel as well. have to see if there is a process to just use one helper function to process everything
+
+def extract_text_from_csv(file_path: Path) -> str:
+    """Reads text from a CSV file."""
+    try:
+        import pandas as pd
+        df = pd.read_csv(file_path, dtype=str, header=None)
+        text = "\n".join([",".join(row.dropna().astype(str)) for _, row in df.iterrows()])
+        return text
+    except Exception as e:
+        print(f"Error extracting text from CSV {file_path}: {e}")
+        return ""
+
+def extract_text_from_image(file_path: Path) -> str:
+    """Extract text from an image using OCR."""
+    try:
+        from PIL import Image
+        import pytesseract
+        return pytesseract.image_to_string(Image.open(file_path))
+    except Exception as e:
+        print(f"Error extracting text from image {file_path}: {e}")
+        return ""
+
+# TODO: consider adding Excel support and unifying extraction logic
 
 # Models for API requests and responses
 class FolderList(BaseModel):
@@ -179,7 +200,6 @@ def index_files_from_folders(folders: List[str], custom_folders: List[str]):
             
             # Get all indexed file paths and their modification times
             results = metadata_collection.get()
-            print("what is the metadata",results)
             indexed_files = {}
             if results and "metadatas" in results and results["metadatas"]:
                 for metadata in results["metadatas"]:
@@ -218,7 +238,15 @@ def index_files_from_folders(folders: List[str], custom_folders: List[str]):
         for directory in directories:
             # Process files recursively through all subdirectories
             for file in directory.glob("**/*"):
-                if file.is_file() and file.suffix.lower() in [".pdf", ".docx", ".txt"]:
+                if file.is_file() and file.suffix.lower() in [
+                    ".pdf",
+                    ".docx",
+                    ".txt",
+                    ".csv",
+                    ".png",
+                    ".jpg",
+                    ".jpeg",
+                ]:
                     filepath_str = str(file.absolute())
                     last_modified = file.stat().st_mtime
                     
@@ -241,12 +269,17 @@ def index_files_from_folders(folders: List[str], custom_folders: List[str]):
             
             filepath_str = str(file.absolute())
             
-            if file.suffix.lower() == ".pdf":
+            suffix = file.suffix.lower()
+            if suffix == ".pdf":
                 text = extract_text_from_pdf(file)
-            elif file.suffix.lower() == ".docx":
+            elif suffix == ".docx":
                 text = extract_text_from_docx(file)
-            elif file.suffix.lower() == ".txt":
+            elif suffix == ".txt":
                 text = extract_text_from_txt(file)
+            elif suffix == ".csv":
+                text = extract_text_from_csv(file)
+            elif suffix in [".png", ".jpg", ".jpeg"]:
+                text = extract_text_from_image(file)
             else:
                 continue  # Skip unsupported file types
             
@@ -268,8 +301,11 @@ def index_files_from_folders(folders: List[str], custom_folders: List[str]):
             
             # Split text into chunks
             chunks = text_splitter.split_text(text)
-            
-            # Add chunks to collection
+
+            # Prepare batch lists for faster embedding
+            batch_docs = []
+            batch_ids = []
+            batch_metadatas = []
             for idx, chunk in enumerate(chunks):
                 doc_id = f"{file.stem}_{int(last_modified)}_{idx}"
                 metadata = {
@@ -279,11 +315,16 @@ def index_files_from_folders(folders: List[str], custom_folders: List[str]):
                     "type": file.suffix.lower().strip("."),
                     "filename": file.name
                 }
-                collection.add(
-                    documents=[chunk],
-                    ids=[doc_id],
-                    metadatas=[metadata]
-                )
+                batch_docs.append(chunk)
+                batch_ids.append(doc_id)
+                batch_metadatas.append(metadata)
+
+            # Add all chunks in one call to reduce API overhead
+            collection.add(
+                documents=batch_docs,
+                ids=batch_ids,
+                metadatas=batch_metadatas
+            )
             
             # Update file metadata
             metadata_collection.upsert(
@@ -418,9 +459,7 @@ async def search(query: str = Query(..., min_length=1)):
                 similarity = 1 - distance if distance is not None else None
                 
                 filepath = metadata.get("source", "Unknown path")
-                print("filepath", filepath)
                 filename = metadata.get("filename", "Unknown filename")
-                print("filename", filename)
                 file_type = metadata.get("type", Path(filepath).suffix[1:] if Path(filepath).suffix else "Unknown type")
                 
                 # Get document content if available
@@ -448,4 +487,4 @@ async def search(query: str = Query(..., min_length=1)):
 
 if __name__ == "__main__":
     import uvicorn
-    uvicorn.run("api:app", host="0.0.0.0", port=8000, reload= True)
+    uvicorn.run("api:app", host="0.0.0.0", port=8000, reload=True)

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  /* config options here */
+};
+
+module.exports = nextConfig;

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,7 +1,0 @@
-import type { NextConfig } from "next";
-
-const nextConfig: NextConfig = {
-  /* config options here */
-};
-
-export default nextConfig;

--- a/frontend/src/components/FolderSelectionModal.tsx
+++ b/frontend/src/components/FolderSelectionModal.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useState, useEffect } from 'react';
-import { getAvailableFolders, startIndexing, IndexingRequest } from '@/services/api';
+import { useState, useEffect, useCallback } from 'react';
+import { getAvailableFolders, IndexingRequest } from '@/services/api';
 
 interface FolderSelectionModalProps {
   isOpen: boolean;
@@ -17,13 +17,7 @@ export default function FolderSelectionModal({ isOpen, onClose, onStartIndexing 
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    if (isOpen) {
-      fetchAvailableFolders();
-    }
-  }, [isOpen]);
-
-  const fetchAvailableFolders = async () => {
+  const fetchAvailableFolders = useCallback(async () => {
     setIsLoading(true);
     setError(null);
     try {
@@ -40,7 +34,13 @@ export default function FolderSelectionModal({ isOpen, onClose, onStartIndexing 
     } finally {
       setIsLoading(false);
     }
-  };
+  }, []);
+
+  useEffect(() => {
+    if (isOpen) {
+      fetchAvailableFolders();
+    }
+  }, [isOpen, fetchAvailableFolders]);
 
   const handleFolderToggle = (folder: string) => {
     if (selectedFolders.includes(folder)) {

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -41,7 +41,7 @@ export interface CollectionStatus {
   document_count: number;
 }
 
-const API_URL = 'http://localhost:8000';
+const API_URL = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:8000';
 
 /**
  * Search for documents based on a semantic query

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,11 @@
+{
+  "version": 2,
+  "builds": [
+    { "src": "frontend/next.config.ts", "use": "@vercel/next" },
+    { "src": "api/index.py", "use": "@vercel/python" }
+  ],
+  "routes": [
+    { "src": "/api/(.*)", "dest": "/api/index.py" },
+    { "src": "(.*)", "dest": "/frontend$1" }
+  ]
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,11 @@
+{
+  "version": 2,
+  "builds": [
+    { "src": "frontend/package.json", "use": "@vercel/next" },
+    { "src": "api/index.py", "use": "@vercel/python" }
+  ],
+  "routes": [
+    { "src": "/api/(.*)", "dest": "/api/index.py" },
+    { "src": "(.*)", "dest": "/frontend$1" }
+  ]
+}


### PR DESCRIPTION
## Summary
- add OCR and CSV text extraction helpers
- include CSV and image formats in indexing list
- fix trailing newline for uvicorn run
- document CSV and image support
- optimize indexing by batching chunks
- add Vercel deployment config
- clean up stray debug prints

## Testing
- `python3 -m py_compile backend/api.py backend/query.py backend/main.py backend/sentence_transformer_embedding_function.py`
- `npm run lint` *(fails: `next: not found`)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6853660737148328b75d804143866ac7